### PR TITLE
Verify against sbt 2.0.0-RC12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ val root = project.in(file("."))
       scalaBinaryVersion.value match {
         case "2.10" => "0.13.18"
         case "2.12" => "1.12.5"
-        case "3"    => "2.0.0-RC9"
+        case "3"    => "2.0.0-RC12"
       }
     },
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.5
+sbt.version=1.12.9


### PR DESCRIPTION
## Summary
  - Update the project sbt version to 1.12.9
  - Update the scripted sbt version for sbt 2.x to 2.0.0-RC12 (from RC9)

  ## Test plan
  - [x] `sbt clean +test +scripted` passes across all three Scala/sbt version combinations