### PR TITLE
Update the scripted sbt versions to 1.12.11 and 2.0.0-RC13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,8 @@ val root = project.in(file("."))
     scriptedSbt := {
       scalaBinaryVersion.value match {
         case "2.10" => "0.13.18"
-        case "2.12" => "1.12.5"
-        case "3"    => "2.0.0-RC12"
+        case "2.12" => "1.12.11"
+        case "3"    => "2.0.0-RC13"
       }
     },
 


### PR DESCRIPTION
Bumps the sbt versions used by `scriptedSbt` for the cross-build:

  - Scala 2.12 axis: `1.12.5` → `1.12.11`
  - Scala 3    axis: `2.0.0-RC12` → `2.0.0-RC13`

  The Scala 2.10 axis (sbt `0.13.18`) is left untouched, as is
  `pluginCrossBuild / sbtVersion` (kept pinned low for binary compatibility).

  Verified locally with:

      sbt --java-home $(java_home -v 17) clean +test +scripted

  All three scripted axes (2.10.7 / 2.12.21 / 3.8.2) pass, and the launcher
  output confirms the inner sbt invocations use the new versions:

      welcome to sbt 1.12.11 (Eclipse Adoptium Java 17.0.19)
      welcome to sbt 2.0.0-RC13 (Eclipse Adoptium Java 17.0.19)