### PR TITLE
Update sbt to 2.0.0 / 1.12.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ val root = project.in(file("."))
     scriptedSbt := {
       scalaBinaryVersion.value match {
         case "2.10" => "0.13.18"
-        case "2.12" => "1.12.11"
+        case "2.12" => "1.12.12"
         case "3"    => "2.0.0"
       }
     },

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ val root = project.in(file("."))
       scalaBinaryVersion.value match {
         case "2.10" => "0.13.18"
         case "2.12" => "1.12.11"
-        case "3"    => "2.0.0-RC16"
+        case "3"    => "2.0.0"
       }
     },
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.11
+sbt.version=1.12.12


### PR DESCRIPTION
sbt 2.0.0 has been released (final). Three changes, one per commit:

- **Scripted sbt 2.x version → 2.0.0**: bumps the scripted (integration test) sbt
  2.x version on the Scala 3 cross-build from `2.0.0-RC16` to the final `2.0.0`.
- **Project sbt version → 1.12.12**: bumps the sbt version used to build the
  plugin itself (`project/build.properties`) from `1.12.11` to `1.12.12`.
- **Scripted sbt 1.x version → 1.12.12**: bumps the scripted sbt 1.x version on
  the Scala 2.12 cross-build from `1.12.11` to `1.12.12`.

Left untouched: the sbt 0.13 scripted version (`0.13.18`) and
`pluginCrossBuild / sbtVersion`.

### Verification
`sbt --java-home $(/usr/libexec/java_home -v 17) +scripted` passes across all
cross-builds (sbt 0.13.18, 1.12.12, and 2.0.0). The build ran under sbt 1.12.12,
the sbt 1.x scripted run used sbt 1.12.12, and the sbt 2.x scripted run used
`sbt-launch-2.0.0.jar`.