### PR TITLE
Update the scripted sbt 1.x version to 1.12.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: sbt-ide-settings plugin Build & Run Scripted Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ val root = project.in(file("."))
     scriptedSbt := {
       scalaBinaryVersion.value match {
         case "2.10" => "0.13.18"
-        case "2.12" => "1.12.12"
+        case "2.12" => "1.12.13"
         case "3"    => "2.0.0"
       }
     },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.12
+sbt.version=1.12.13


### PR DESCRIPTION
sbt 1.12.13 has been released. This bumps the scripted (integration test) sbt 1.x
version on the Scala 2.12 cross-build from `1.12.12` to `1.12.13`, so the plugin's
scripted tests run against the latest sbt 1.x patch release.

Only the sbt 1.x scripted version changes. Left untouched:
- the sbt 2.x scripted version (`2.0.0`) and sbt 0.13 scripted version (`0.13.18`)
- `pluginCrossBuild / sbtVersion`
- the plugin's own build sbt version (`project/build.properties` = `1.12.12`)

### Verification
`sbt --java-home $(/usr/libexec/java_home -v 17) +scripted` passes across all
cross-builds (sbt 0.13.18, 1.12.13, and 2.0.0). The sbt 1.x scripted run
bootstrapped sbt 1.12.13 and the sbt 2.x run used `sbt-launch-2.0.0.jar`.