### PR TITLE
Update the scripted sbt version to 2.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ val root = project.in(file("."))
       scalaBinaryVersion.value match {
         case "2.10" => "0.13.18"
         case "2.12" => "1.12.13"
-        case "3"    => "2.0.0"
+        case "3"    => "2.0.1"
       }
     },
 


### PR DESCRIPTION
sbt 2.0.1 has been released. This bumps the scripted (integration test) sbt 2.x
version on the Scala 3 cross-build from `2.0.0` to `2.0.1`, so the plugin's
scripted tests run against the latest sbt 2.x patch release.

Only the sbt 2.x scripted version changes. Left untouched:
- the sbt 1.x scripted version (`1.12.13`) and sbt 0.13 scripted version (`0.13.18`)
- `pluginCrossBuild / sbtVersion`
- the plugin's own build sbt version (`project/build.properties` = `1.12.13`)

### Verification
`sbt --java-home $(/usr/libexec/java_home -v 17) +scripted` passes across all
cross-builds (sbt 0.13.18, 1.12.13, and 2.0.1). The sbt 2.x scripted run used
`sbt-launch-2.0.1.jar`.